### PR TITLE
Update Readme with correct Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ vagrant plugin install vagrant-alpine
 ## Usage
 
 ```
-$ vagrant init maier/alpine-3.1.3
+$ vagrant init maier/alpine-3.1.3-x86_64
 $ vagrant up
 ```
 


### PR DESCRIPTION
https://atlas.hashicorp.com/maier/boxes/alpine-3.1.3 returns a 404 currently.
