### PR TITLE
fix the --fqdn no longer available in 3.8

### DIFF
--- a/lib/vagrant-alpine/cap/change_host_name.rb
+++ b/lib/vagrant-alpine/cap/change_host_name.rb
@@ -67,7 +67,7 @@ module VagrantPlugins
         end
 
         def update_mailname
-          sudo('hostname --fqdn > /etc/mailname')
+          sudo('hostname -f > /etc/mailname')
         end
 
         def renew_dhcp


### PR DESCRIPTION
This also makes the use of hostname -f consistent. Before there was use
of hostname -f and hostname --fqdn, after this change its only hostname
-f.

fixes #30

Signed-off-by: BlackEagle <ike.devolder@gmail.com>